### PR TITLE
fixed the syntax coloring issue when a comma is present within an htm…

### DIFF
--- a/jaggeryjs.tmLanguage
+++ b/jaggeryjs.tmLanguage
@@ -336,7 +336,7 @@
     </dict>
     <dict>
       <key>begin</key>
-      <string>{|]|,</string>
+      <string>{|]</string>
       <key>captures</key>
       <dict>
         <key>0</key>


### PR DESCRIPTION
There is a syntax coloring issue in .jag files when a comma(,) is present within any html tag.
![screenshot from 2015-08-12 10 33 50](https://cloud.githubusercontent.com/assets/13759167/9216866/aa514c1c-40dd-11e5-9b79-b684ae0115b3.png)

Please refer to line number 51. If the comma is removed from <p> tag then the syntax coloring works fine. This issue appeared after the commit  0cbb4328d8f50a84b0a1b5436a3351aea0b3d8bb (syntax added for jaggery.conf file)

I checked out the previous commit and tested, and the issue was not present. 

I have tested both .jag files and conf.jag files after my fix. I couldn't find any issue. please review. 
